### PR TITLE
using another method of returning unauthorized

### DIFF
--- a/authorizer.js
+++ b/authorizer.js
@@ -10,6 +10,11 @@ exports.handler = function(event, context, callback) {
 
   if (!isAuthorized(event.authorizationToken, secret)) {
     callback('Unauthorized') // eslint-disable-line standard/no-callback-literal
+    // the eslint-callback-literal check is disabled because it's
+    // not applicable here. the check itself is designed to prevent
+    // people from returning error messages as string literals instead
+    // of using the Error class. This is at odds with the api provided to us.
+    // Alternatively s/callback/ca_ll__back/ to avoid the linter and comment.
   }
 
   callback(null, {

--- a/authorizer.js
+++ b/authorizer.js
@@ -1,32 +1,19 @@
 const { isAuthorized, runIfDev } = require('./utils')
 
-exports.handler = async function(event) {
+exports.handler = function(event, context, callback) {
+
   const secret = process.env.JWT_SECRET
   if (!secret) {
     console.log('Error acquiring secret from env')
 
-    // We're ignoring this lint error because the Lambdas are configured to respond
-    // to a thrown string 'JWTSecretError'. For the moment we'll leave this as is
-    // but long-term we should reconfigure the lambda to respond to a thrown Error
-    // instead of an explicit literal string
-    // TODO: reconfigure lambda to respond to a thrown Error instead of literal 'JWTSecretError'
-
-    // eslint-disable-next-line no-throw-literal
-    throw 'JWTSecretError'
+    throw Error('JWTSecretError')
   }
 
   if (!isAuthorized(event.authorizationToken, secret)) {
-    // We're ignoring this lint error because the Lambdas are configured to respond
-    // to a thrown string 'Unauthorized'. For the moment we'll leave this as is
-    // but long-term we should reconfigure the lambda to respond to a thrown Error
-    // instead of an explicit literal string. The configuration
-    // TODO: reconfigure lambda to respond to a thrown Error instead of literal 'Unauthorized'
-
-    // eslint-disable-next-line no-throw-literal
-    throw 'Unauthorized'
+    callback("Unauthorized")
   }
 
-  return {
+  callback(null, {
     principalId: event.authorizationToken,
     policyDocument: {
       Version: '2012-10-17',
@@ -38,7 +25,7 @@ exports.handler = async function(event) {
         }
       ]
     }
-  }
+  })
 }
 
 runIfDev(exports.handler)

--- a/authorizer.js
+++ b/authorizer.js
@@ -1,7 +1,6 @@
 const { isAuthorized, runIfDev } = require('./utils')
 
 exports.handler = function(event, context, callback) {
-
   const secret = process.env.JWT_SECRET
   if (!secret) {
     console.log('Error acquiring secret from env')
@@ -10,7 +9,7 @@ exports.handler = function(event, context, callback) {
   }
 
   if (!isAuthorized(event.authorizationToken, secret)) {
-    callback("Unauthorized")
+    callback('Unauthorized') // eslint-disable-line standard/no-callback-literal
   }
 
   callback(null, {


### PR DESCRIPTION
This changeset switches us from using throws to communicate
unauthorized. the throws resulted in errors when tied to monitoring
systems, this resolves that so we can alert on actual failure.

As we have been testing we've seen a large number of lambda failures which trigger pager duty alerts. Researching the failures indicated that they were normal "deny" responses that were resulting in throws which the runtime logged as failures but interpreted reasonably by returning a 403.

Documentation uses the synchronous calls and mentions using throws to return "unauthorized" when running from an async handler. I have not been able to find a way to return "unauthorized" from the async handler without a throw, so I've gone sync.
